### PR TITLE
Add light/dark theme toggle with system preference support

### DIFF
--- a/cta-tracker/src/app/app.component.css
+++ b/cta-tracker/src/app/app.component.css
@@ -19,13 +19,15 @@ nav {
   position: fixed;
   bottom: 0;
   left: 0;
-  background-color: hsla(0, 0%, 13%, 0.98);
+  background-color: var(--nav-bg);
+  border-top: 1px solid var(--nav-border);
   z-index: 10;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
 nav a:visited,
 nav a {
-  color: var(--cta-grey);
+  color: var(--nav-link);
   text-decoration: none;
   cursor: pointer;
   width: 100%;
@@ -53,13 +55,13 @@ nav ul li {
 }
 
 nav ul li.active a {
-  color: #FFFFFF;
+  color: var(--nav-link-active);
 }
 
 @supports (backdrop-filter: blur(15px)) {
   nav {
     backdrop-filter: saturate(180%) blur(20px);
-    background-color: hsla(0, 0%, 13%, 0.3);
+    background-color: var(--nav-bg-blur);
   }
 
   /* nav ul li {

--- a/cta-tracker/src/app/app.config.ts
+++ b/cta-tracker/src/app/app.config.ts
@@ -1,9 +1,10 @@
-import { ApplicationConfig, provideZoneChangeDetection, isDevMode } from '@angular/core';
+import { ApplicationConfig, provideZoneChangeDetection, isDevMode, provideAppInitializer, inject } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideServiceWorker } from '@angular/service-worker';
 
 import { routes } from './app.routes';
+import { ThemeService } from './services/theme.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -13,6 +14,9 @@ export const appConfig: ApplicationConfig = {
     provideServiceWorker('ngsw-worker.js', {
       enabled: !isDevMode(),
       registrationStrategy: 'registerWhenStable:30000'
+    }),
+    provideAppInitializer(() => {
+      inject(ThemeService);
     })
   ]
 };

--- a/cta-tracker/src/app/arrivals/arrivals.component.css
+++ b/cta-tracker/src/app/arrivals/arrivals.component.css
@@ -22,7 +22,7 @@
   border-radius: 8px;
   z-index: 2;
   /* background-color: hsla(202, 52%, 11%, 0.6); */
-  background-color: #191919;
+  background-color: var(--surface-card);
   /* backdrop-filter: saturate(180%) blur(20px);  */
 }
 
@@ -51,7 +51,7 @@
   font-size: 40px;
   line-height: 40px;
   border-radius: 4px;
-  background-color: #333333;
+  background-color: var(--surface-elevated);
 }
 
 .time-left {
@@ -65,8 +65,8 @@
 .route-number {
   border-radius: 4px;
   padding: 0 4px;
-  background: #FFFFFF;
-  color: #000000;
+  background: var(--route-badge-bg);
+  color: var(--route-badge-text);
 }
 
 .delayed {

--- a/cta-tracker/src/app/directions/directions.component.css
+++ b/cta-tracker/src/app/directions/directions.component.css
@@ -3,7 +3,7 @@
 }
 
 a {
-  color: white;
+  color: var(--text-primary);
   text-decoration: none;
   height: 100%;
   width: 100%;

--- a/cta-tracker/src/app/favorites/favorites.component.css
+++ b/cta-tracker/src/app/favorites/favorites.component.css
@@ -1,3 +1,14 @@
+.header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+}
+
+.settings-icon {
+  cursor: pointer;
+}
+
 .favorite-list {
   display: grid;
   grid-auto-rows: 72px
@@ -9,7 +20,7 @@
   width: 100%;
   display: block;
   text-decoration: none;
-  color: #FFFFFF;
+  color: var(--text-primary);
   font-weight: 900;
   font-size: 22px;
 }

--- a/cta-tracker/src/app/favorites/favorites.component.html
+++ b/cta-tracker/src/app/favorites/favorites.component.html
@@ -1,6 +1,7 @@
-<h1 class="cols-3">Favorites</h1>
-<span class="cols-reverse-1" (click)="openFavoriteSettings = !openFavoriteSettings">
-  *
+<h1 class="cols-2">Favorites</h1>
+<span class="cols-reverse-1 header-actions">
+  <app-theme-toggle></app-theme-toggle>
+  <span class="settings-icon" (click)="openFavoriteSettings = !openFavoriteSettings">*</span>
 </span>
 @if (openFavoriteSettings) {
   <article class="cols-4 grid-4 favorite-settings">

--- a/cta-tracker/src/app/favorites/favorites.component.ts
+++ b/cta-tracker/src/app/favorites/favorites.component.ts
@@ -5,12 +5,13 @@ import { FavoritesService } from '../services/favorites.service';
 import { Favorite } from '../services/Favorite';
 import { Observable } from 'rxjs';
 import { HttpResponse, HttpErrorResponse } from '@angular/common/http';
+import { ThemeToggleComponent } from '../theme-toggle/theme-toggle.component';
 
 @Component({
   selector: 'app-favorites',
   templateUrl: './favorites.component.html',
   styleUrls: ['./favorites.component.css'],
-  imports: [RouterLink, AsyncPipe, SlicePipe]
+  imports: [RouterLink, AsyncPipe, SlicePipe, ThemeToggleComponent]
 })
 export class FavoritesComponent implements OnInit {
   favorites$: Observable<Array<Favorite>> | undefined;

--- a/cta-tracker/src/app/routes/routes.component.css
+++ b/cta-tracker/src/app/routes/routes.component.css
@@ -3,7 +3,7 @@
 }
 
 a {
-  color: white;
+  color: var(--text-primary);
   text-decoration: none;
   height: 100%;
   width: 100%;
@@ -33,7 +33,7 @@ a {
   font-size: 22px;
   /* border-bottom: 1px solid #1DE7DB; */
   /* box-shadow: 0 0 5px #1463F4; */
-  color: #ffffff;
+  color: var(--text-primary);
 }
 
 .bus-route-name {

--- a/cta-tracker/src/app/services/theme.service.ts
+++ b/cta-tracker/src/app/services/theme.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, signal, effect, computed } from '@angular/core';
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+const STORAGE_KEY = 'theme-preference';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  readonly preference = signal<ThemePreference>(this.loadPreference());
+
+  private readonly systemPrefersDark = signal(
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
+
+  readonly resolvedTheme = computed<ResolvedTheme>(() => {
+    const pref = this.preference();
+    if (pref === 'system') {
+      return this.systemPrefersDark() ? 'dark' : 'light';
+    }
+    return pref;
+  });
+
+  readonly isDark = computed(() => this.resolvedTheme() === 'dark');
+
+  constructor() {
+    effect(() => {
+      const theme = this.resolvedTheme();
+      document.documentElement.setAttribute('data-theme', theme);
+
+      const meta = document.querySelector('meta[name="theme-color"]');
+      if (meta) {
+        meta.setAttribute('content', theme === 'dark' ? '#000000' : '#f5f5f7');
+      }
+    });
+
+    window.matchMedia('(prefers-color-scheme: dark)')
+      .addEventListener('change', (e) => {
+        this.systemPrefersDark.set(e.matches);
+      });
+  }
+
+  setPreference(pref: ThemePreference): void {
+    this.preference.set(pref);
+    localStorage.setItem(STORAGE_KEY, pref);
+  }
+
+  toggle(): void {
+    const next = this.resolvedTheme() === 'dark' ? 'light' : 'dark';
+    this.setPreference(next);
+  }
+
+  private loadPreference(): ThemePreference {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
+      return stored;
+    }
+    return 'system';
+  }
+}

--- a/cta-tracker/src/app/stops/stops.component.css
+++ b/cta-tracker/src/app/stops/stops.component.css
@@ -3,7 +3,7 @@
 }
 
 a {
-  color: white;
+  color: var(--text-primary);
   text-decoration: none;
   height: 100%;
   width: 100%;

--- a/cta-tracker/src/app/theme-toggle/theme-toggle.component.css
+++ b/cta-tracker/src/app/theme-toggle/theme-toggle.component.css
@@ -1,0 +1,55 @@
+.theme-toggle {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.toggle-track {
+  position: relative;
+  width: 52px;
+  height: 28px;
+  border-radius: 14px;
+  background-color: var(--gray4);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 6px;
+  transition: background-color 0.3s ease;
+}
+
+.toggle-track.light {
+  background-color: var(--gray3);
+}
+
+.toggle-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  transition: opacity 0.2s ease;
+}
+
+.toggle-icon.sun {
+  color: rgb(255, 200, 50);
+}
+
+.toggle-icon.moon {
+  color: rgb(180, 190, 220);
+}
+
+.toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: var(--text-primary);
+  transition: transform 0.3s ease;
+}
+
+.toggle-thumb.light {
+  transform: translateX(24px);
+}

--- a/cta-tracker/src/app/theme-toggle/theme-toggle.component.html
+++ b/cta-tracker/src/app/theme-toggle/theme-toggle.component.html
@@ -1,0 +1,27 @@
+<button
+  class="theme-toggle"
+  (click)="theme.toggle()"
+  [attr.aria-label]="theme.isDark() ? 'Switch to light mode' : 'Switch to dark mode'"
+  type="button">
+  <span class="toggle-track" [class.light]="!theme.isDark()">
+    <span class="toggle-icon sun" aria-hidden="true">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="5"/>
+        <line x1="12" y1="1" x2="12" y2="3"/>
+        <line x1="12" y1="21" x2="12" y2="23"/>
+        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+        <line x1="1" y1="12" x2="3" y2="12"/>
+        <line x1="21" y1="12" x2="23" y2="12"/>
+        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+      </svg>
+    </span>
+    <span class="toggle-icon moon" aria-hidden="true">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+      </svg>
+    </span>
+    <span class="toggle-thumb" [class.light]="!theme.isDark()"></span>
+  </span>
+</button>

--- a/cta-tracker/src/app/theme-toggle/theme-toggle.component.ts
+++ b/cta-tracker/src/app/theme-toggle/theme-toggle.component.ts
@@ -1,0 +1,11 @@
+import { Component, inject } from '@angular/core';
+import { ThemeService } from '../services/theme.service';
+
+@Component({
+  selector: 'app-theme-toggle',
+  templateUrl: './theme-toggle.component.html',
+  styleUrls: ['./theme-toggle.component.css']
+})
+export class ThemeToggleComponent {
+  protected readonly theme = inject(ThemeService);
+}

--- a/cta-tracker/src/index.html
+++ b/cta-tracker/src/index.html
@@ -16,6 +16,18 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#000000">
+  <script>
+    (function() {
+      var t = localStorage.getItem('theme-preference');
+      if (!t || t === 'system') {
+        t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      }
+      document.documentElement.setAttribute('data-theme', t);
+      if (t === 'light') {
+        document.querySelector('meta[name="theme-color"]').setAttribute('content', '#f5f5f7');
+      }
+    })();
+  </script>
 </head>
 
 <body>

--- a/cta-tracker/src/styles.css
+++ b/cta-tracker/src/styles.css
@@ -7,14 +7,7 @@ a,abbr,acronym,address,applet,article,aside,audio,b,big,blockquote,body,canvas,c
 /* stylelint-enable */
 
 :root {
-  --background: #000000;
-
-  --top-bottom-color: hsl(222, 100%, 5%);
-  --bottom-bar-color: hsla(222, 100%, 5%, 0.3);
-  --bottom-bar-color-reg: hsla(222, 100%, 5%, 0.7);
-  --top-bottom-color-light: hsla(222, 100%, 15%, 0.3);
-  --top-bottom-color-light-reg: hsla(222, 100%, 15%, 0.7);
-
+  /* CTA brand colors (shared across themes) */
   --cta-blue: rgb(0,161,222);
   --cta-blue-opacity: rgba(0,161,222,0.17);
   --cta-red: rgb(198,12,48);
@@ -48,6 +41,32 @@ a,abbr,acronym,address,applet,article,aside,audio,b,big,blockquote,body,canvas,c
   --red-opacity: rgba(226, 94, 63, 0.17);
   --yellow: rgb(255,230,32);
   --yellow-opacity: rgba(255,230,32,0.17);
+}
+
+/* Dark theme (default) */
+:root,
+[data-theme="dark"] {
+  --background: #000000;
+  --text-primary: #FFFFFF;
+  --text-secondary: rgb(142,142,147);
+  --surface: #1e2225;
+  --surface-card: #191919;
+  --surface-elevated: #333333;
+  --nav-bg: hsla(0, 0%, 13%, 0.98);
+  --nav-bg-blur: hsla(0, 0%, 13%, 0.3);
+  --nav-link: rgb(86,90,92);
+  --nav-link-active: #FFFFFF;
+  --input-border: rgba(255,255,255,0.2);
+  --focus-color: #2196F3;
+  --route-badge-bg: #FFFFFF;
+  --route-badge-text: #000000;
+  --nav-border: transparent;
+
+  --top-bottom-color: hsl(222, 100%, 5%);
+  --bottom-bar-color: hsla(222, 100%, 5%, 0.3);
+  --bottom-bar-color-reg: hsla(222, 100%, 5%, 0.7);
+  --top-bottom-color-light: hsla(222, 100%, 15%, 0.3);
+  --top-bottom-color-light-reg: hsla(222, 100%, 15%, 0.7);
 
   --gray: rgb(142,142,147);
   --gray2: rgb(99,99,102);
@@ -57,20 +76,63 @@ a,abbr,acronym,address,applet,article,aside,audio,b,big,blockquote,body,canvas,c
   --gray6: rgb(28,28,30);
 }
 
+/* Light theme */
+[data-theme="light"] {
+  --background: #f5f5f7;
+  --text-primary: #1a1a1a;
+  --text-secondary: rgb(108,108,112);
+  --surface: #ffffff;
+  --surface-card: #ffffff;
+  --surface-elevated: #e8e8ed;
+  --nav-bg: hsla(0, 0%, 97%, 0.98);
+  --nav-bg-blur: hsla(0, 0%, 97%, 0.3);
+  --nav-link: rgb(142,142,147);
+  --nav-link-active: #1a1a1a;
+  --input-border: rgba(0,0,0,0.15);
+  --focus-color: #1976D2;
+  --route-badge-bg: #1a1a1a;
+  --route-badge-text: #FFFFFF;
+  --nav-border: rgba(0,0,0,0.1);
+
+  --top-bottom-color: hsl(222, 20%, 95%);
+  --bottom-bar-color: hsla(222, 20%, 95%, 0.3);
+  --bottom-bar-color-reg: hsla(222, 20%, 95%, 0.7);
+  --top-bottom-color-light: hsla(222, 20%, 85%, 0.3);
+  --top-bottom-color-light-reg: hsla(222, 20%, 85%, 0.7);
+
+  --gray: rgb(142,142,147);
+  --gray2: rgb(174,174,178);
+  --gray3: rgb(199,199,204);
+  --gray4: rgb(209,209,214);
+  --gray5: rgb(229,229,234);
+  --gray6: rgb(242,242,247);
+
+  --cta-blue-opacity: rgba(0,161,222,0.12);
+  --cta-red-opacity: rgba(198,12,48,0.12);
+  --cta-brown-opacity: rgba(98,54,27,0.12);
+  --cta-green-opacity: rgba(0,155,58,0.12);
+  --cta-orange-opacity: rgba(249,70,28,0.12);
+  --cta-purple-opacity: rgba(82,35,152,0.12);
+  --cta-pink-opacity: rgba(226,126,166,0.12);
+  --cta-yellow-opacity: rgba(249,227,0,0.10);
+  --cta-grey-opacity: rgba(86,90,92,0.12);
+  --pink-opacity: rgba(250,17,79,0.12);
+}
+
 * {
   box-sizing: border-box;
 }
 
 html {
-  color: #FFFFFF;
+  color: var(--text-primary);
   background-color: var(--background);
-  /* background: linear-gradient(135deg,var(--background),#000000); */
   font-family: -apple-system, ".SFNSText-Regular", Helvetica, sans-serif;
   font-size: 1.125em;
   line-height: 1.2em;
   min-height: 100%;
   height: 100%;
   touch-action: manipulation;
+  transition: color 0.3s ease, background-color 0.3s ease;
 }
 
 body {
@@ -160,8 +222,8 @@ input, button {
   border-radius: 0;
   height: 56px;
   border: none;
-  border-bottom: 1px solid white;
-  background-color: #1e2225;
+  border-bottom: 1px solid var(--input-border);
+  background-color: var(--surface);
   width: 100%;
   font-weight: 900;
   border: none;
@@ -175,7 +237,7 @@ input, button {
   height: 100%;
   top: 0;
   left: 0;
-  color: #FFFFFF;
+  color: var(--text-primary);
   /* border-radius: 5px; */
   /* background: hsla(220, 43%, 7%, 1); */
   transform: scale(1);
@@ -188,7 +250,7 @@ input, button {
 .search-input:focus ~ .search-label, .search-input:valid ~ .search-label {
   transform-origin: top left;
   transform: scale(0.75) translateY(-50%) translateX(10px);
-  color: #2196F3;
+  color: var(--focus-color);
 }
 
 .fab {
@@ -218,14 +280,14 @@ input, button {
 }
 
 input[type=number]:focus ~ label, input[type=number]:valid ~ label {
-  color: var(--white);
+  color: var(--text-primary);
   transform-origin: bottom;
   transform: translateY(-130.9%) translateX(-0.7272em); /* 16px / 22px = 0.7272em */
 }
 
 input[type=number] {
   background-color: var(--gray2);
-  color: var(--white);
+  color: var(--text-primary);
   text-align: center;
   font-size: 1.309em;
   line-height: 1.309em;


### PR DESCRIPTION
Implement a comprehensive theming system following Angular best practices:

- ThemeService: signal-based singleton with light/dark/system preference,
  persisted to localStorage, listens for OS prefers-color-scheme changes
- ThemeToggleComponent: standalone sun/moon toggle, easy to relocate
- CSS custom properties: semantic variables (--text-primary, --surface,
  --surface-card, etc.) with dark and light theme values
- FOUC prevention: inline script in index.html resolves theme before render
- provideAppInitializer ensures service bootstraps before components
- All hardcoded colors replaced with theme-aware CSS variables across
  every component (arrivals, routes, stops, directions, favorites, nav)
- Light theme uses iOS-style gray scale and accessible contrast ratios
- Smooth 0.3s transition on theme switch, subtle nav border in light mode

Toggle placed in Favorites page header; component is self-contained
for easy migration to a future bottom tab.

https://claude.ai/code/session_01JfrB9T1XG241JTzqpoEkTY