### PR TITLE
Add follow bus page to track a bus across upcoming stops

### DIFF
--- a/cta-tracker/src/app/app.routes.ts
+++ b/cta-tracker/src/app/app.routes.ts
@@ -13,7 +13,7 @@ export const routes: Routes = [
   { path: 'directions/:route', component: DirectionsComponent },
   { path: 'stops/:route/:direction', component: StopsComponent },
   { path: 'arrivals/:route/:direction/:stopId/:stopName', component: ArrivalsComponent },
-  { path: 'arrivals/:route/:direction/:stopId/:vehicleId', component: FollowVehicleComponent },
+  { path: 'follow/:vehicleId', component: FollowVehicleComponent },
   { path: 'favorites', component: FavoritesComponent },
   { path: '**', redirectTo: '/routes' }
 ];

--- a/cta-tracker/src/app/arrivals/arrivals.component.css
+++ b/cta-tracker/src/app/arrivals/arrivals.component.css
@@ -128,6 +128,12 @@
   }
 }
 
+.follow-link {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
 @keyframes refresh {
   from {
     transform: rotate(0) scale(1);

--- a/cta-tracker/src/app/arrivals/arrivals.component.html
+++ b/cta-tracker/src/app/arrivals/arrivals.component.html
@@ -8,23 +8,25 @@
   @if (vehicles$ | async; as vehicles) {
     @for (vehicle of vehicles; track vehicle.vid) {
       <li class="an-arrival" [class.loading]="refreshing">
-        <ul class="grid-4 arrivals-area">
-          <li class="destination">
-            @if (vehicle.dly) {
-              <span class="delayed">DELAYED</span>
-            }
-            To {{ vehicle.des }}
-          </li>
-          <li class="route">
-            <span class="route-number">RT {{ vehicle.rt }}</span>
-          </li>
-          <li class="minutes-left">
-            {{ vehicle.prdctdn }}{{ vehicle.prdctdn | timeuntil:'minutes' }}
-          </li>
-          <li class="time-left">
-            {{ vehicle.prdctdn | timeuntil:'time' }}
-          </li>
-        </ul>
+        <a [routerLink]="['/follow', vehicle.vid]" [queryParams]="{from: forStopId}" class="follow-link">
+          <ul class="grid-4 arrivals-area">
+            <li class="destination">
+              @if (vehicle.dly) {
+                <span class="delayed">DELAYED</span>
+              }
+              To {{ vehicle.des }}
+            </li>
+            <li class="route">
+              <span class="route-number">RT {{ vehicle.rt }}</span>
+            </li>
+            <li class="minutes-left">
+              {{ vehicle.prdctdn }}{{ vehicle.prdctdn | timeuntil:'minutes' }}
+            </li>
+            <li class="time-left">
+              {{ vehicle.prdctdn | timeuntil:'time' }}
+            </li>
+          </ul>
+        </a>
       </li>
     }
   }

--- a/cta-tracker/src/app/arrivals/arrivals.component.ts
+++ b/cta-tracker/src/app/arrivals/arrivals.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { AsyncPipe } from '@angular/common';
 import { BusService } from '../services/bus.service';
 import { BustimeResponse, Prd, Error } from '../busResponse';
@@ -12,7 +12,7 @@ import { TimeuntilPipe } from '../timeuntil.pipe';
   selector: 'app-arrivals',
   templateUrl: './arrivals.component.html',
   styleUrls: ['./arrivals.component.css'],
-  imports: [AsyncPipe, TimeuntilPipe]
+  imports: [AsyncPipe, TimeuntilPipe, RouterLink]
 })
 export class ArrivalsComponent implements OnInit, OnDestroy {
   forRoute = '';

--- a/cta-tracker/src/app/follow-vehicle/follow-vehicle.component.css
+++ b/cta-tracker/src/app/follow-vehicle/follow-vehicle.component.css
@@ -1,0 +1,135 @@
+.subheader {
+  color: var(--text-secondary);
+  margin-bottom: 16px;
+  font-weight: 600;
+}
+
+.predictions-list {
+  display: grid;
+  row-gap: 2px;
+  width: 100%;
+  padding-bottom: calc(56px + 16px);
+}
+
+.a-prediction {
+  background-color: var(--surface-card);
+  border-left: 3px solid transparent;
+}
+
+.a-prediction:first-child {
+  border-radius: 8px 8px 0 0;
+}
+
+.a-prediction:last-child {
+  border-radius: 0 0 8px 8px;
+}
+
+.from-stop {
+  border-left-color: var(--cta-blue);
+  background-color: var(--cta-blue-opacity);
+}
+
+.prediction-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+}
+
+.prediction-left {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.stop-name {
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stop-id {
+  font-size: 0.8em;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.prediction-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  flex-shrink: 0;
+  margin-left: 16px;
+}
+
+.minutes {
+  font-weight: 900;
+  font-size: 1.4em;
+  line-height: 1;
+}
+
+.time {
+  font-size: 0.8em;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.route-number {
+  border-radius: 4px;
+  padding: 0 4px;
+  background: var(--route-badge-bg);
+  color: var(--route-badge-text);
+}
+
+.delayed {
+  border-radius: 4px;
+  background-color: var(--pink-opacity);
+  color: var(--pink);
+  padding: 0 4px;
+  font-size: 0.85em;
+  font-weight: 700;
+}
+
+.loading {
+  animation: loading 0.5s linear 1;
+}
+
+@keyframes loading {
+  0% {
+    transform: scale(1) translateY(0);
+  }
+
+  50% {
+    transform: scale(1.02) translateY(4px);
+  }
+
+  100% {
+    transform: scale(1) translateY(0);
+  }
+}
+
+.button-refresh {
+  background-color: var(--cta-grey);
+}
+
+.refreshing {
+  animation: refresh 0.5s linear 0s 1;
+  animation-fill-mode: forwards;
+}
+
+@keyframes refresh {
+  from {
+    transform: rotate(0) scale(1);
+  }
+  50% {
+    transform: rotate(180deg) scale(1.3);
+  }
+  to {
+    transform: rotate(360deg) scale(1);
+  }
+}

--- a/cta-tracker/src/app/follow-vehicle/follow-vehicle.component.html
+++ b/cta-tracker/src/app/follow-vehicle/follow-vehicle.component.html
@@ -1,3 +1,38 @@
-<p>
-  follow-vehicle works!
-</p>
+<h2 class="cols-4">
+  <span class="route-number">RT {{ routeNumber }}</span>
+  Bus #{{ vehicleId }} {{ direction }}
+</h2>
+<p class="cols-4 subheader">To {{ destination }}</p>
+<ul class="cols-4 predictions-list">
+  @if (error$ | async; as errors) {
+    @for (anError of errors; track anError.msg) {
+      <li>{{ anError.msg }}</li>
+    }
+  }
+  @if (predictions$ | async; as predictions) {
+    @for (prediction of predictions; track prediction.stpid) {
+      <li class="a-prediction" [class.loading]="refreshing" [class.from-stop]="prediction.stpid === fromStopId">
+        <div class="prediction-row">
+          <div class="prediction-left">
+            <span class="stop-name">{{ prediction.stpnm }}</span>
+            <span class="stop-id">
+              Stop #{{ prediction.stpid }}
+              @if (prediction.dly) {
+                <span class="delayed">DELAYED</span>
+              }
+            </span>
+          </div>
+          <div class="prediction-right">
+            <span class="minutes">{{ prediction.prdctdn }}{{ prediction.prdctdn | timeuntil:'minutes' }}</span>
+            <span class="time">{{ prediction.prdctdn | timeuntil:'time' }}</span>
+          </div>
+        </div>
+      </li>
+    }
+  }
+</ul>
+@if (canRefresh) {
+  <button class="fab button-refresh" (click)="getFollowData()">
+    <img src="assets/icons/ic_refresh_black_24px.svg" class="icon" [class.refreshing]="refreshing">
+  </button>
+}

--- a/cta-tracker/src/app/follow-vehicle/follow-vehicle.component.ts
+++ b/cta-tracker/src/app/follow-vehicle/follow-vehicle.component.ts
@@ -1,8 +1,102 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { AsyncPipe } from '@angular/common';
+import { BusService } from '../services/bus.service';
+import { BustimeResponse, Prd, Error } from '../busResponse';
+import { of, Observable, timer, Subscription } from 'rxjs';
+import { TimeuntilPipe } from '../timeuntil.pipe';
 
 @Component({
   selector: 'app-follow-vehicle',
   templateUrl: './follow-vehicle.component.html',
-  styleUrls: ['./follow-vehicle.component.css']
+  styleUrls: ['./follow-vehicle.component.css'],
+  imports: [AsyncPipe, TimeuntilPipe]
 })
-export class FollowVehicleComponent {}
+export class FollowVehicleComponent implements OnInit, OnDestroy {
+  vehicleId = 0;
+  fromStopId = '';
+  routeNumber = '';
+  direction = '';
+  destination = '';
+  predictions$: Observable<Prd[]> | undefined;
+  error$: Observable<Error[]> | undefined;
+  refreshInterval = 30 * 1000;
+  timerRef: Subscription | undefined;
+  canRefresh = false;
+  refreshing = false;
+
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private busService: BusService
+  ) {}
+
+  ngOnInit(): void {
+    this.activatedRoute.queryParams.subscribe(qp => {
+      this.fromStopId = qp['from'] || '';
+    });
+    this.activatedRoute.params.subscribe(params => {
+      this.canRefresh = true;
+      this.vehicleId = +params['vehicleId'];
+      this.timerRef = timer(0, this.refreshInterval).subscribe(() => {
+        this.getFollowData();
+      });
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.timerRef?.unsubscribe();
+  }
+
+  getFollowData(): void {
+    if (!this.refreshing) {
+      this.busService.follow(this.vehicleId).subscribe((response: BustimeResponse) => {
+        this.handleResponse(response);
+      });
+    }
+  }
+
+  handleResponse(response: BustimeResponse): void {
+    this.refreshing = true;
+    if (response.error) {
+      this.error$ = of(response.error);
+    } else if (response.prd) {
+      if (response.prd.length > 0) {
+        this.routeNumber = response.prd[0].rt;
+        this.direction = response.prd[0].rtdir;
+        this.destination = response.prd[0].des;
+      }
+      for (let i = 0; i < response.prd.length; i++) {
+        if (response.prd[i].dly) {
+          response.prd[i].prdctdn = this.getMinutesDifference(
+            response.prd[i].tmstmp,
+            response.prd[i].prdtm);
+        }
+      }
+      this.predictions$ = of(response.prd);
+    }
+    setTimeout(() => this.refreshing = false, 500);
+    if (typeof window.navigator.vibrate !== 'undefined') {
+      window.navigator.vibrate(5);
+    }
+  }
+
+  getMinutesDifference(now: string, future: string): string {
+    try {
+      const minutes: string = (((this.getDate(future).getTime() - this.getDate(now).getTime()) / 1000) / 60).toFixed(0);
+      return +minutes > 1 ? minutes : 'DUE';
+    } catch {
+      return 'DLY';
+    }
+  }
+
+  getDate(date: string): Date {
+    const dateTime: string[] = date.split(' ');
+    return new Date(
+      +dateTime[0].slice(0, 4),
+      +dateTime[0].slice(4, 6) - 1,
+      +dateTime[0].slice(6, 8),
+      +dateTime[1].slice(0, 2),
+      +dateTime[1].slice(3, 5)
+    );
+  }
+}

--- a/cta-tracker/src/styles.css
+++ b/cta-tracker/src/styles.css
@@ -147,7 +147,8 @@ app-favorites,
 app-routes,
 app-directions,
 app-stops,
-app-arrivals {
+app-arrivals,
+app-follow-vehicle {
   padding: 16px;
   display: grid;
   grid-column-gap: 16px;


### PR DESCRIPTION
Implement FollowVehicleComponent with auto-refresh, fix route conflict by moving to /follow/:vehicleId, make arrival cards tappable to navigate to the follow page, and highlight the user's origin stop.