### PR TITLE
Add last refreshed timestamp to bus and train arrivals pages

### DIFF
--- a/cta-tracker/src/app/arrivals/arrivals.component.css
+++ b/cta-tracker/src/app/arrivals/arrivals.component.css
@@ -8,10 +8,17 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  margin-bottom: 20px;
+  margin-bottom: 4px;
   padding: 4px 10px;
   background: var(--bus-countdown-bg);
   border-radius: 6px;
+}
+.last-refreshed {
+  display: block;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-weight: 500;
+  margin-bottom: 16px;
 }
 
 /* Arrivals List */

--- a/cta-tracker/src/app/arrivals/arrivals.component.html
+++ b/cta-tracker/src/app/arrivals/arrivals.component.html
@@ -1,6 +1,9 @@
 <div class="stop-header cols-4">
   <h2>{{ forStopName }}</h2>
   <span class="direction-label">{{ forDirection }}</span>
+  @if (lastRefreshed) {
+    <span class="last-refreshed">Last refreshed at {{ lastRefreshed | date:'h:mm:ss a' }}</span>
+  }
 </div>
 <ul class="cols-4 arrivals-list">
   @if (isInitialLoading) {

--- a/cta-tracker/src/app/arrivals/arrivals.component.ts
+++ b/cta-tracker/src/app/arrivals/arrivals.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, DatePipe } from '@angular/common';
 import { BusService } from '../services/bus.service';
 import { BustimeResponse, Prd, Error } from '../busResponse';
 import { of, Observable, timer, Subscription } from 'rxjs';
@@ -12,7 +12,7 @@ import { TimeuntilPipe } from '../timeuntil.pipe';
   selector: 'app-arrivals',
   templateUrl: './arrivals.component.html',
   styleUrls: ['./arrivals.component.css'],
-  imports: [AsyncPipe, TimeuntilPipe, RouterLink]
+  imports: [AsyncPipe, DatePipe, TimeuntilPipe, RouterLink]
 })
 export class ArrivalsComponent implements OnInit, OnDestroy {
   readonly skeletonCards = [0, 1, 2];
@@ -30,6 +30,7 @@ export class ArrivalsComponent implements OnInit, OnDestroy {
   canRefresh = false;
   refreshing = false;
   isInitialLoading = true;
+  lastRefreshed: Date | null = null;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -78,6 +79,7 @@ export class ArrivalsComponent implements OnInit, OnDestroy {
   handleArrivalsResponse(response: BustimeResponse): void {
     this.isInitialLoading = false;
     this.refreshing = true;
+    this.lastRefreshed = new Date();
     if (response.error) {
       this.error$ = of(response.error);
       this.vehicles$ = undefined;

--- a/cta-tracker/src/app/train-arrivals/train-arrivals.component.css
+++ b/cta-tracker/src/app/train-arrivals/train-arrivals.component.css
@@ -1,6 +1,13 @@
 /* Stop Header */
 .stop-header { margin-bottom: 8px; }
 .stop-header h2 { margin-bottom: 4px; letter-spacing: -0.02em; }
+.last-refreshed {
+  display: block;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-weight: 500;
+  margin-bottom: 8px;
+}
 
 /* Direction Label */
 .direction-label {

--- a/cta-tracker/src/app/train-arrivals/train-arrivals.component.html
+++ b/cta-tracker/src/app/train-arrivals/train-arrivals.component.html
@@ -1,5 +1,8 @@
 <div class="stop-header cols-4">
   <h2>{{ stationName }}</h2>
+  @if (lastRefreshed) {
+    <span class="last-refreshed">Last refreshed at {{ lastRefreshed | date:'h:mm:ss a' }}</span>
+  }
 </div>
 @if (isInitialLoading) {
   <ul class="cols-4 arrivals-list">

--- a/cta-tracker/src/app/train-arrivals/train-arrivals.component.ts
+++ b/cta-tracker/src/app/train-arrivals/train-arrivals.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, DatePipe } from '@angular/common';
 import { TrainService } from '../services/train.service';
 import { TrainApiResponse, TrainEta, TRAIN_LINE_CSS_MAP, TRAIN_DIRECTION_MAP } from '../trainResponse';
 import { FavoritesService } from '../services/favorites.service';
@@ -22,7 +22,7 @@ interface ArrivalGroup {
   selector: 'app-train-arrivals',
   templateUrl: './train-arrivals.component.html',
   styleUrls: ['./train-arrivals.component.css'],
-  imports: [AsyncPipe, TimeuntilPipe, RouterLink]
+  imports: [AsyncPipe, DatePipe, TimeuntilPipe, RouterLink]
 })
 export class TrainArrivalsComponent implements OnInit, OnDestroy {
   readonly skeletonCards = [0, 1, 2];
@@ -40,6 +40,7 @@ export class TrainArrivalsComponent implements OnInit, OnDestroy {
   isFavorite = true;
   favoriteStop: Favorite | undefined;
   favorited = false;
+  lastRefreshed: Date | null = null;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -95,6 +96,7 @@ export class TrainArrivalsComponent implements OnInit, OnDestroy {
   handleResponse(response: TrainApiResponse): void {
     this.isInitialLoading = false;
     this.refreshing = true;
+    this.lastRefreshed = new Date();
 
     if (response.ctatt.errCd !== '0' && response.ctatt.errNm) {
       this.errorMsg = response.ctatt.errNm;


### PR DESCRIPTION
Shows the time with seconds when arrivals data was last fetched,
displayed under the direction label. Uses theme variables for
light/dark mode compatibility.

https://claude.ai/code/session_0135FB713qsFYSBCgo4pCm75