### PR TITLE
Display "Last refreshed" timestamp in bus and train arrivals headers

### DIFF
--- a/cta-tracker/src/app/arrivals/arrivals.component.css
+++ b/cta-tracker/src/app/arrivals/arrivals.component.css
@@ -1,17 +1,29 @@
 /* Stop Header */
-.stop-header { margin-bottom: 8px; }
-.stop-header h2 { margin-bottom: 4px; letter-spacing: -0.02em; }
+.stop-header {
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.stop-header h2 { margin: 0; letter-spacing: -0.02em; }
 .direction-label {
   display: inline-flex;
-  color: var(--text-tertiary);
+  width: fit-content;
+  color: var(--text-secondary);
   font-size: 12px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  margin-bottom: 20px;
   padding: 4px 10px;
   background: var(--bus-countdown-bg);
   border-radius: 6px;
+}
+
+.last-refreshed {
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.35;
 }
 
 /* Arrivals List */

--- a/cta-tracker/src/app/arrivals/arrivals.component.html
+++ b/cta-tracker/src/app/arrivals/arrivals.component.html
@@ -1,6 +1,9 @@
 <div class="stop-header cols-4">
   <h2>{{ forStopName }}</h2>
   <span class="direction-label">{{ forDirection }}</span>
+  @if (lastRefreshedAt) {
+    <span class="last-refreshed">Last refreshed {{ lastRefreshedAt }}</span>
+  }
 </div>
 <ul class="cols-4 arrivals-list">
   @if (isInitialLoading) {

--- a/cta-tracker/src/app/arrivals/arrivals.component.ts
+++ b/cta-tracker/src/app/arrivals/arrivals.component.ts
@@ -30,6 +30,7 @@ export class ArrivalsComponent implements OnInit, OnDestroy {
   canRefresh = false;
   refreshing = false;
   isInitialLoading = true;
+  lastRefreshedAt = '';
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -78,6 +79,7 @@ export class ArrivalsComponent implements OnInit, OnDestroy {
   handleArrivalsResponse(response: BustimeResponse): void {
     this.isInitialLoading = false;
     this.refreshing = true;
+    this.updateLastRefreshedAt();
     if (response.error) {
       this.error$ = of(response.error);
       this.vehicles$ = undefined;
@@ -128,5 +130,13 @@ export class ArrivalsComponent implements OnInit, OnDestroy {
         }, 300);
       });
     }
+  }
+
+  private updateLastRefreshedAt(): void {
+    this.lastRefreshedAt = new Date().toLocaleTimeString([], {
+      hour: 'numeric',
+      minute: '2-digit',
+      second: '2-digit'
+    });
   }
 }

--- a/cta-tracker/src/app/train-arrivals/train-arrivals.component.css
+++ b/cta-tracker/src/app/train-arrivals/train-arrivals.component.css
@@ -3,17 +3,33 @@
 .stop-header h2 { margin-bottom: 4px; letter-spacing: -0.02em; }
 
 /* Direction Label */
+.direction-header {
+  margin-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .direction-label {
   font-size: 12px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-tertiary);
-  margin-bottom: 8px;
+  margin: 0;
   padding: 4px 10px;
   background: var(--bus-countdown-bg);
   border-radius: 6px;
   display: inline-flex;
+  width: fit-content;
+}
+
+.last-refreshed {
+  margin: 0;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.35;
 }
 
 /* Arrivals List */

--- a/cta-tracker/src/app/train-arrivals/train-arrivals.component.html
+++ b/cta-tracker/src/app/train-arrivals/train-arrivals.component.html
@@ -26,7 +26,12 @@
   }
   @if (arrivalGroups$ | async; as groups) {
     @for (group of groups; track group.directionLabel) {
-      <h3 class="cols-4 direction-label">{{ group.directionLabel }}</h3>
+      <div class="cols-4 direction-header">
+        <h3 class="direction-label">{{ group.directionLabel }}</h3>
+        @if (lastRefreshedAt) {
+          <p class="last-refreshed">Last refreshed {{ lastRefreshedAt }}</p>
+        }
+      </div>
       <ul class="cols-4 arrivals-list">
         @for (arrival of group.arrivals; track arrival.rn + arrival.stpId) {
           <li class="arrival-card" [class.loading]="refreshing">

--- a/cta-tracker/src/app/train-arrivals/train-arrivals.component.ts
+++ b/cta-tracker/src/app/train-arrivals/train-arrivals.component.ts
@@ -40,6 +40,7 @@ export class TrainArrivalsComponent implements OnInit, OnDestroy {
   isFavorite = true;
   favoriteStop: Favorite | undefined;
   favorited = false;
+  lastRefreshedAt = '';
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -95,6 +96,7 @@ export class TrainArrivalsComponent implements OnInit, OnDestroy {
   handleResponse(response: TrainApiResponse): void {
     this.isInitialLoading = false;
     this.refreshing = true;
+    this.updateLastRefreshedAt();
 
     if (response.ctatt.errCd !== '0' && response.ctatt.errNm) {
       this.errorMsg = response.ctatt.errNm;
@@ -153,6 +155,14 @@ export class TrainArrivalsComponent implements OnInit, OnDestroy {
     } catch {
       return '--';
     }
+  }
+
+  private updateLastRefreshedAt(): void {
+    this.lastRefreshedAt = new Date().toLocaleTimeString([], {
+      hour: 'numeric',
+      minute: '2-digit',
+      second: '2-digit'
+    });
   }
 
   addToFavorite(): void {


### PR DESCRIPTION
### Motivation
- Provide a visible refresh timestamp so users know when arrival data was last updated. 
- Surface the refresh time for both bus and train arrival screens to improve UX and clarity. 

### Description
- Added a `lastRefreshedAt` property and `updateLastRefreshedAt()` helper to both `ArrivalsComponent` and `TrainArrivalsComponent` and call it when handling API responses. 
- Updated `arrivals.component.html` and `train-arrivals.component.html` to conditionally render a `Last refreshed {{ lastRefreshedAt }}` element in the stop/direction header. 
- Adjusted CSS in `arrivals.component.css` and `train-arrivals.component.css` to layout the header area using flex, add `.last-refreshed` styling, and refine direction label/header spacing and colors. 

### Testing
- Ran the project unit test suite with `ng test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d3a2f798832f9207709833ffb11b)